### PR TITLE
Allow someone to append a command.  i.e. load their bash profile before ...

### DIFF
--- a/shell_turtlestein.py
+++ b/shell_turtlestein.py
@@ -44,6 +44,8 @@ def exec_args(cmd):
     return args
 
 def exec_cmd(window, cwd, cmd):
+    if settings().get('cmd_append'):
+        cmd = settings().get('cmd_append') + " && " + cmd
     args = exec_args(cmd)
     args.update({'cmd': cmd, 'shell': True, 'working_dir': cwd})
     window.run_command("exec", args)


### PR DESCRIPTION
...running a command (source ~/.profile)

Fixes issue #2

Example:

``` json
{
  "cmd_append":"source ~/.profile",
  "cmd_config": [],
  "input_widget": {
    "syntax": "Packages/ShellScript/Shell-Unix-Generic.tmLanguage"
  }
}
```

Runs:

![](https://dl.dropbox.com/u/71697/jing/2012-02-16_0021.png)

![](https://dl.dropbox.com/u/71697/jing/2012-02-16_0024.png)
