### PR TITLE
Race condition for OS X

### DIFF
--- a/shell_turtlestein.py
+++ b/shell_turtlestein.py
@@ -146,7 +146,7 @@ class ShellPromptCommand(sublime_plugin.WindowCommand):
                 # Since Sublime's build system doesn't support piping to STDIN
                 # directly, use a tempfile.
                 text = "".join([active_view.substr(r) for r in input_regions])
-                temp = tempfile.NamedTemporaryFile()
+                temp = tempfile.NamedTemporaryFile(delete=False)
                 temp.write(text.encode('utf8'))
                 shell_cmd = "%s < %s" % (shell_cmd, pipes.quote(temp.name))
             exec_args = settings['exec_args']


### PR DESCRIPTION
There is an apparent race condition here since "exec" fires asynchronously.

It appears the temp file is considered closed when the variable goes out of scope and so the file may be deleted before the command is actually run.  This leads to fun statuses messages like:

```
/bin/sh: /var/folders/_w/10xgs8850ss_c6mn6cpvzlhw0000gn/T/tmpLQNlNY: No such file or directory
[Finished in 0.0s with exit code 1]
```

Setting `delete=False` prevents this however I'm not sure what the best way to clean up these temporary files after the fact is (or if the operating systems will eventually do it themselves.)
