### PR TITLE
Support for encoding different than UTF-8

### DIFF
--- a/shell_turtlestein.py
+++ b/shell_turtlestein.py
@@ -49,7 +49,7 @@ def cmd_settings(cmd):
     Return the default settings with settings for the command merged in
     """
     d = {}
-    for setting in ['exec_args', 'surround_cmd']:
+    for setting in ['exec_args', 'surround_cmd', 'encoding']:
         d[setting] = settings().get(setting)
     try:
         settings_for_cmd = (c for c
@@ -159,6 +159,8 @@ class ShellPromptCommand(sublime_plugin.WindowCommand):
                 shell_cmd = "%s < %s" % (shell_cmd, pipes.quote(temp.name))
             exec_args = settings['exec_args']
             exec_args.update({'cmd': shell_cmd, 'shell': True, 'working_dir': cwd})
+            if settings['encoding']:
+                exec_args.update({'encoding': settings['encoding']})
 
             self.window.run_command("exec", exec_args)
 


### PR DESCRIPTION
A fix for issue #34
In my case I had to add "encoding": "cp1252" in the sublime-settings file to make it work
